### PR TITLE
Advertise typing support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Lint
       run: |
         make lint
+    - name: Typing
+      run: |
+        make mypy
     - name: Test
       run: |
         make test

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,13 @@ help:
 
 
 install:
-	pip3 install -e .[dev]
+	python -m pip install --editable '.[dev]'
 
 lint:
-	flake8 pyiso4 tests --max-line-length=120 --ignore=N802
+	python -m flake8 pyiso4 tests --max-line-length=120 --ignore=N802
+
+mypy:
+	python -m mypy pyiso4 tests
 
 test:
 	python -m unittest discover -s tests

--- a/pyiso4/lexer.py
+++ b/pyiso4/lexer.py
@@ -1,4 +1,4 @@
-from typing import List, Iterable
+from typing import List, Iterable, Optional
 from enum import Enum, unique
 from unicodedata import normalize
 import re
@@ -46,17 +46,17 @@ class Token:
 
 
 class Lexer:
-    def __init__(self, inp, stopwords: List[str]):
+    def __init__(self, inp: str, stopwords: List[str]) -> None:
         self.input = normalize('NFC', inp)
         self.pos = 0
         self.count = -1
         self.start_word = 0
-        self.current_word = None
+        self.current_word: Optional[str] = None
         self.stopwords = stopwords
 
         self.next()
 
-    def _skip_space(self):
+    def _skip_space(self) -> None:
         while self.pos < len(self.input) and self.input[self.pos] in SPACES:
             self.pos += 1
 
@@ -77,7 +77,7 @@ class Lexer:
         self.count += 1
 
     def tokenize(self) -> Iterable[Token]:
-        def yield_hyphenated(word: str, base_pos: int):
+        def yield_hyphenated(word: str, base_pos: int) -> Iterable[Token]:
             is_first = True
             len_ = 0
             for w in word.split('-'):

--- a/pyiso4/normalize_string.py
+++ b/pyiso4/normalize_string.py
@@ -9,7 +9,7 @@ BOUNDARY = re.compile(r'[-\s\u2013\u2014_.,:;!|=+*\\/"()&#%@$?]')
 LIGATURES = 'ŒœÆæ'
 
 
-def number_of_ligatures(word: str):
+def number_of_ligatures(word: str) -> int:
     return sum(1 for c in word if c in LIGATURES)
 
 

--- a/pyiso4/prefix_tree.py
+++ b/pyiso4/prefix_tree.py
@@ -32,7 +32,7 @@ class Node:
             self.objs.append((key, obj))
             self._split(position)
 
-    def _split(self, position) -> None:
+    def _split(self, position: int) -> None:
         """Split the node if it contains too much objects"""
 
         if not self.split and self.char is not None and len(self.objs) > self.MAX_OBJS:
@@ -76,7 +76,7 @@ class PrefixTree:
     """Prefix tree that return correct results up to a certain point (depending on `Node.MAX_OBJS`).
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.root = Node('')
 
     def insert(self, key: str, obj: Any) -> None:

--- a/pyiso4/script.py
+++ b/pyiso4/script.py
@@ -6,7 +6,7 @@ import pyiso4
 from pyiso4.ltwa import Abbreviate
 
 
-def get_arguments_parser():
+def get_arguments_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=pyiso4.__doc__)
     parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + pyiso4.__version__)
 
@@ -30,7 +30,7 @@ def get_arguments_parser():
     return parser
 
 
-def main():
+def main() -> None:
     args = get_arguments_parser().parse_args()
 
     # load LTWA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=62"]
+
 [project]
 name = "pyiso4"
 dynamic = ["version"]
-authors = [
-    {name = "Pierre Beaujean", email = "pierre.beaujean@unamur.be"},
-]
 description = "Abbreviate a scientific journal title following the ISO-4 rules"
 readme = "README.md"
 license = {file = "LICENSE"}
+authors = [{name = "Pierre Beaujean", email = "pierre.beaujean@unamur.be"}]
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -14,30 +16,39 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-
 dependencies = [
-    'unidecode'
+    "unidecode",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "flake8",
-    "flake8-quotes",
     "autopep8",
     "bump2version",
+    "flake8",
+    "flake8-quotes",
+    "mypy",
 ]
 
 [project.scripts]
-iso4abbreviate = 'pyiso4.script:main'
+iso4abbreviate = "pyiso4.script:main"
 
 [tool.setuptools]
-packages = ['pyiso4']
+packages = ["pyiso4"]
+
+[tool.setuptools.package-data]
+pyiso4 = ["py.typed"]
 
 [tool.setuptools.dynamic]
 version = {attr = "pyiso4.__version__"}
+
+[tool.mypy]
+strict = true
+hide_error_codes = false
+warn_unused_ignores = true

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 
 from pyiso4.lexer import Lexer, TokenType
 from pyiso4.ltwa import Pattern, Abbreviate
@@ -8,7 +9,7 @@ from pyiso4.normalize_string import normalize, Level, number_of_ligatures
 class TestNormalize(unittest.TestCase):
     """Test the unicode normalization"""
 
-    def test_normalize(self):
+    def test_normalize(self) -> None:
         tests = [
             ('test', 'test'),
             ('abbréviation', 'abbreviation'),
@@ -21,7 +22,7 @@ class TestNormalize(unittest.TestCase):
         for inp, out in tests:
             self.assertEqual(out, normalize(inp, Level.NORMAL))
 
-    def test_normalize_extra(self):
+    def test_normalize_extra(self) -> None:
         tests = [
             ('TeSt', 'test'),
             ("Côte-d'Azur", 'cote d azur')
@@ -30,17 +31,14 @@ class TestNormalize(unittest.TestCase):
         for inp, out in tests:
             self.assertEqual(out, normalize(inp, Level.HARD))
 
-    def test_ligatures(self):
+    def test_ligatures(self) -> None:
         self.assertEqual(number_of_ligatures('test'), 0)
         self.assertEqual(number_of_ligatures('coeur'), 0)
         self.assertEqual(number_of_ligatures('cœur'), 1)
 
 
 class TestLexer(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def test_stopword(self):
+    def test_stopword(self) -> None:
         stopwords = ['x', 'y']
         text = ' '.join(stopwords)
 
@@ -54,13 +52,13 @@ class TestLexer(unittest.TestCase):
         for t in tokens[:-1]:  # skip EOS
             self.assertEqual(t.type, TokenType.STOPWORD)
 
-    def test_token_position(self):
+    def test_token_position(self) -> None:
         text = 'this is a test-case for you'
         for t in Lexer(text, []).tokenize():
             if t.position >= 0:
                 self.assertEqual(text[t.position], t.value[0])
 
-    def test_hyphenated_words(self):
+    def test_hyphenated_words(self) -> None:
         cpd1 = 'état'
         cpd2 = 'nation'
         text = '{}-{}'.format(cpd1, cpd2)
@@ -71,7 +69,7 @@ class TestLexer(unittest.TestCase):
         self.assertEqual(tokens[2].type, TokenType.WORD)
         self.assertEqual(tokens[2].value, cpd2)
 
-    def test_surname_as_abbreviation(self):
+    def test_surname_as_abbreviation(self) -> None:
         abbrv = 'A.'
         text = 'Legacy of {} Einstein'.format(abbrv)
         tokens = list(Lexer(text, ['of']).tokenize())
@@ -82,7 +80,7 @@ class TestLexer(unittest.TestCase):
 
 
 class TestPattern(unittest.TestCase):
-    def test_pattern_match(self):
+    def test_pattern_match(self) -> None:
         text = 'abc'
 
         # no dash
@@ -114,7 +112,7 @@ class TestPattern(unittest.TestCase):
         self.assertTrue(pattern.match(word + 's'))  # plural form
         self.assertFalse(pattern.match(word + 'x'))  # not an inflexion
 
-    def test_patter_match_on_sentence(self):
+    def test_patter_match_on_sentence(self) -> None:
         # no dash
         text = 'abc'
         pattern_without_dash = Pattern.from_line('{}\tx\tmul'.format(text))
@@ -133,11 +131,11 @@ class TestPattern(unittest.TestCase):
 
 
 class TestAbbreviate(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.abbreviate = Abbreviate.create()
 
-    def test_abbreviations(self):
+    def test_abbreviations(self) -> None:
         with open('tests/tests.tsv') as f:
             for line in f.readlines():
                 fields = line.split('\t')


### PR DESCRIPTION
The main point of this was to add a `py.typed` marker so that users can get the typing annotations.

To make sure that all works nicely, it also
* Adds a barebones `mypy` configuration
* Adds a `mypy` step to the CI
* Fixes all the reported issues by `mypy --strict`.