### PR TITLE
Fix IndexError when abbrv is longer than original; Close #12

### DIFF
--- a/pyiso4/lexer.py
+++ b/pyiso4/lexer.py
@@ -132,7 +132,7 @@ class Lexer:
                     yield Token(TokenType.PART, word, self.start_word)
                     was_part = self.count
                 # check if ordinal (preceded by PART)
-                elif IS_ORDINAL.match(word) and self.count == was_part + 1:
+                elif IS_ORDINAL.fullmatch(word) and self.count == was_part + 1:
                     yield Token(TokenType.ORDINAL, word, self.start_word)
                 # check if article (after ordinal, so "a" is detected as ordinal if preceded by PART)
                 elif lower_word in ARTICLES:
@@ -155,6 +155,7 @@ class Lexer:
             # yield the remaining symbols, if any
             if len(end_symbols) > 0:
                 yield Token(TokenType.SYMBOLS, end_symbols, self.pos - len(end_symbols))
+                was_part = self.count
 
             self.next()
 

--- a/pyiso4/ltwa.py
+++ b/pyiso4/ltwa.py
@@ -177,6 +177,9 @@ class Abbreviate:
         """Matches the capitalization and diacritics of the `original` word, as long as they are similar
         """
 
+        if len(abbrv) > len(original):
+            abbrv = abbrv[:len(original)]
+
         normalized_abbrv = list(normalize(abbrv, Level.SOFT))
         for i, c in enumerate(normalized_abbrv):
             unided = unidecode(original[i])

--- a/tests/tests.tsv
+++ b/tests/tests.tsv
@@ -41,3 +41,5 @@ International Journal of e-Collaboration	Int. J. e-Collab.
 Proceedings of A. Razmadze Mathematical Institute	Proc. A. Razmadze Math. Inst.
 Norsk Militært Tidsskrift	Nor. Mil. Tidsskr.
 Proceedings of the 2024 Conference on Science	Proc. 2024 Conf. Sci.
+IEEE Power and Energy Magazine	IEEE Power Energy Mag.
+IEEE Transactions on Automatic Control	IEEE Trans. Autom. Control

--- a/tests/tests.tsv
+++ b/tests/tests.tsv
@@ -43,3 +43,9 @@ Norsk Militært Tidsskrift	Nor. Mil. Tidsskr.
 Proceedings of the 2024 Conference on Science	Proc. 2024 Conf. Sci.
 IEEE Power and Energy Magazine	IEEE Power Energy Mag.
 IEEE Transactions on Automatic Control	IEEE Trans. Autom. Control
+E.S.A. bulletin	E.S.A. bull.
+Acta Universitatis Carolinae. Iuridica	Acta Univ. Carol., Iurid.
+Physical Review. A	Phys. Rev., A
+Physical Review. D	Phys. Rev., D
+Physical Review. E	Phys. Rev., E
+Physical Review. I	Phys. Rev., I


### PR DESCRIPTION
In some cases, there is a mismatch between abbreviation and original, where a dot is added to an unabbreviated word, e.g., "Control". If this occurs, the dot is removed and the abbreviation is reduced to the length of the original word.

This closes #12 